### PR TITLE
Add bridge state endpoint and tracking

### DIFF
--- a/NAS/README.md
+++ b/NAS/README.md
@@ -27,6 +27,7 @@ docker compose -f docker-compose.radicale.yml up -d
 
 ### Bridge HTTP endpoints
 - `POST /status_update` — accepts calendar state JSON and republishes to MQTT.
+- `GET /status` — returns the last state seen by the bridge (or `null`).
 - `GET /radicale/list` — lists events from Radicale as JSON (optional).
 - `POST /radicale/upsert` — upserts `uid` + `vevent` (optional).
 


### PR DESCRIPTION
## Summary
- track the bridge's latest state so that it can be reused across handlers
- expose a GET /status endpoint that returns the last known state via HTTP
- document the new endpoint alongside the existing bridge API description

## Testing
- python -m compileall NAS/bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68e14df84ffc8333be3285bb9c8fe1e0