### PR TITLE
Add bridge health endpoint for state monitoring

### DIFF
--- a/NAS/README.md
+++ b/NAS/README.md
@@ -27,6 +27,7 @@ docker compose -f docker-compose.radicale.yml up -d
 
 ### Bridge HTTP endpoints
 - `POST /status_update` — accepts calendar state JSON and republishes to MQTT.
+- `GET /healthz` — returns uptime, MQTT connection status, and the most recent state metadata.
 - `GET /radicale/list` — lists events from Radicale as JSON (optional).
 - `POST /radicale/upsert` — upserts `uid` + `vevent` (optional).
 


### PR DESCRIPTION
## Summary
- track the most recent published state within the NAS bridge service
- add a GET /healthz endpoint that reports uptime, MQTT connectivity, and last state metadata
- document the new health endpoint in the NAS README

## Testing
- python -m compileall NAS/bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68e14df367f08333ae8ae7822b162b32