### PR TITLE
Add MQTT bridge health endpoint and state tracking

### DIFF
--- a/NAS/README.md
+++ b/NAS/README.md
@@ -29,6 +29,7 @@ docker compose -f docker-compose.radicale.yml up -d
 - `POST /status_update` — accepts calendar state JSON and republishes to MQTT.
 - `GET /radicale/list` — lists events from Radicale as JSON (optional).
 - `POST /radicale/upsert` — upserts `uid` + `vevent` (optional).
+- `GET /health` — returns MQTT connection status and details of the last published state.
 
 ### Env
 - `NTFY_STATUS_TOPIC` must match your Power Automate ntfy POST URL.


### PR DESCRIPTION
## Summary
- add MQTT connection tracking and a reusable publish helper to the bridge
- expose a new GET /health endpoint with details about the last published state
- document the new endpoint in the NAS README

## Testing
- python -m compileall NAS/bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68e14de54374833392dec7d232fbd4bb